### PR TITLE
fix navbar dropdown menu not showing

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -157,7 +157,6 @@
 
 .navbar {
     background-color: var(--bs-white);
-    height: 6.5rem;
 }
 
 .navbar .span-as-title {


### PR DESCRIPTION
## Description

When the page is visualized on mobile phones the navbar dropdown not shows when the user clicks he hamburger button
it is because of the set navigation bar height. to solve the problem the height of the navbar was removed 